### PR TITLE
Update radiod.conf

### DIFF
--- a/radiod.conf
+++ b/radiod.conf
@@ -233,7 +233,7 @@ ky040_r1_fitted=no
 station_names=list
 
 # Action on exiting radio. Stop radio only, shutdown the system or execute program
-# 1) Shutdown system: exit_action=stop_radio
+# 1) Shutdown system: exit_action=shutdown
 # 2) Exit to operating system: exit_action=stop_radio
 # 3) Execute a program: exit_action=<programm name>
 #    For example: exit_action=/usr/share/radio/weather.py


### PR DESCRIPTION
The radiod.conf comment for exit_action lists `stop_radio` as the value to use to shutdown the system.  It looks like this should be `shutdown` (as seen in the default value.)